### PR TITLE
[FEAT] Add code shrinking, optimization, and obfuscation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,11 +27,17 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        create("staging") {
+            initWith(getByName("release"))
+            isDebuggable = false
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {


### PR DESCRIPTION
Enable R8 code shrinking, optimization, and obfuscation in build.gradle.kts.

New build variant "staging" is created, so we can still use "debug" for normal running.

isDebuggable is disabled in "staging" or code would be only shrunk, but not optimized or obfuscated.