### PR TITLE
[FEAT] Add vertical scroll to CharacterDetailScreen

### DIFF
--- a/app/src/main/java/com/example/rickandmorty/ui/character/CharacterDetailScreen.kt
+++ b/app/src/main/java/com/example/rickandmorty/ui/character/CharacterDetailScreen.kt
@@ -18,8 +18,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -90,7 +92,9 @@ fun CharacterDetail(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
-            modifier = modifier.padding(dimensionResource(R.dimen.medium))
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .padding(dimensionResource(R.dimen.medium))
         ) {
             AsyncImage(
                 model = ImageRequest.Builder(context = LocalContext.current)


### PR DESCRIPTION
In landscape mode, not all elements of CharacterDetailScreen are visible. This can be fixed by adding vertical scroll.